### PR TITLE
Support preloadCode to inject script to the browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
             "cordova-android": ">=9.0.0",
             "cordova-ios": ">=6.0.0"
           },
-          "6.0.0": {
+          "6.0.1-dev": {
             "cordova": ">=9.0.0",
             "cordova-android": ">=10.0.0",
             "cordova-ios": ">=6.0.0"

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -69,7 +69,7 @@
 @property (nonatomic) NSURL* currentURL;
 
 - (void)forceClose;
-- (void)navigateTo:(NSURL*)url;
+- (void)navigateTo:(NSURL*)url preloadCode:(NSString *)preloadCode;
 - (void)updateNavigationButtons;
 
 - (id)initWithBrowserOptions: (CDVInAppBrowserOptions*) browserOptions andSettings:(NSDictionary*) settings;

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -98,7 +98,7 @@
         }
     };
 
-    module.exports = function (strUrl, strWindowName, strWindowFeatures, callbacks) {
+    module.exports = function (strUrl, strWindowName, strWindowFeatures, preloadCode, callbacks) {
         // Don't catch calls that write to existing frames (e.g. named iframes).
         if (window.frames && window.frames[strWindowName]) {
             const origOpenFunc = modulemapper.getOriginalSymbol(window, 'open');
@@ -119,7 +119,7 @@
 
         strWindowFeatures = strWindowFeatures || '';
 
-        exec(cb, cb, 'InAppBrowser', 'open', [strUrl, strWindowName, strWindowFeatures]);
+        exec(cb, cb, 'InAppBrowser', 'open', [strUrl, strWindowName, strWindowFeatures, preloadCode]);
         return iab;
     };
 })();


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
This PR lets us inject a script into the webpage.


### Description
Script should be passed right after browser options as a new input.



### Testing
Tested it on iOS.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
