### PR TITLE
Aligned text and icons in android toolbar

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -937,7 +937,7 @@ public class InAppBrowser extends CordovaPlugin {
                 titleTextView.setGravity(Gravity.CENTER_VERTICAL);
                 titleTextView.setLayoutParams(textLayoutParams);
                 titleTextView.setId(Integer.valueOf(4));
-                titleTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 17);
+                titleTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
                 titleTextView.setTypeface(null, Typeface.BOLD);
                 titleTextView.setText(title);
 

--- a/src/android/res/drawable/ic_action_close.xml
+++ b/src/android/res/drawable/ic_action_close.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/src/android/res/drawable/ic_action_more.xml
+++ b/src/android/res/drawable/ic_action_more.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <group>

--- a/src/android/res/drawable/ic_action_previous_item.xml
+++ b/src/android/res/drawable/ic_action_previous_item.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path


### PR DESCRIPTION
Aligned text and icons in android toolbar

### Platforms affected
Android


### Motivation and Context
Fix UI issues



### Description
Aligned with 20dp sizing



### Testing
-



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
